### PR TITLE
Added Hama transparent yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project aims to centralize, maintain and expose an exhaustive list of all b
 
 | Brands | Color Count | Style |
 | -------- | -------- | -------- | 
-| Hama     | 60     | Melty Bead |
+| Hama     | 62     | Melty Bead |
 | Perler     | 78     | Melty Bead | 
 | Perler Mini     |  41   | Melty Bead | 
 | Perler Caps     |  26   | Bead | 

--- a/raw/hama.csv
+++ b/raw/hama.csv
@@ -11,6 +11,7 @@ H10,Green,2,118,67,Jeppewl
 H11,Light green,25,205,167,Jeppewl
 H12,Brown,62,39,26,Jeppewl
 H13,Transparent Red,192,36,53,LThanda
+H14,Transparent Yellow,228,170,50,galaxy
 H16,Transparent Green,55,184,118,LThanda
 H17,Grey,131,143,152,Jeppewl
 H18,Black,20,19,21,Jeppewl


### PR DESCRIPTION
Noticed that Hama 14 Transparent Yellow was missing. Added it using the same method I used for my last PR, using colorpicker in gimp from the colorchart pdf.

On a different note, I noticed that H39 - H41 has been discontinued for a while. I dunno if they should be removed, since someone might still have them (and maybe odd stores might still have in stock) so it would be useful to keep for some people. Also in case they are reintroduced again. Which makes me think it would be useful to be able to add tags to colors, such as discontinued, transparent, metallic, glitter etc. Then in Beadifier (and other apps that could use this repo?) could have a toggle to toggle all of the colors in those tags in one go.