### PR TITLE
Add Artkal colors CE01-CE17

### DIFF
--- a/raw/artkal_c.csv
+++ b/raw/artkal_c.csv
@@ -155,3 +155,20 @@ C65,Mango,239,126,46,Exodeca1
 C66,Wild Watermelon,252,108,133,Exodeca1
 C67,Orchid,177,78,181,Exodeca1
 C68,Toothpaste Blue,105,194,238,Exodeca1
+CE01,Columbia Blue,195,206,214,felix-oq
+CE02,Pale Cerulean,154,178,219,felix-oq
+CE03,Silver Lake Blue,93,136,178,felix-oq
+CE04,Sky Blue (Crayola),2,189,209,felix-oq
+CE05,Maximum Blue Green,82,202,172,felix-oq
+CE06,Bright Navy Blue,45,109,178,felix-oq
+CE07,Black Shadows,194,163,183,felix-oq
+CE08,Mountbatten Pink,138,88,119,felix-oq
+CE09,Halayà Úbe,104,53,93,felix-oq
+CE10,Deep Mauve,184,79,168,felix-oq
+CE11,Heliotrope Magenta,176,47,164,felix-oq
+CE12,Rajah,226,163,101,felix-oq
+CE13,Earth Yellow,190,142,89,felix-oq
+CE14,Chinese Bronze,168,116,67,felix-oq
+CE15,Alloy Orange,160,110,82,felix-oq
+CE16,Orchid Pink,249,193,215,felix-oq
+CE17,Caput Mortuum,89,41,43,felix-oq


### PR DESCRIPTION
Since there are no official RGB codes (yet), the colors were manually sampled from the photos included in the latest 2024 color chart: https://de.artkalfusebeads.com/pages/c-color-chart

Also, I couldn't find the corresponding color names on the official Artkal website, so I took them from this online shop: https://hamabeads.co/product-category/productos/productos-mini/mini2-6mm/