### PR TITLE
Update artkal_c.csv

### DIFF
--- a/raw/artkal_c.csv
+++ b/raw/artkal_c.csv
@@ -59,7 +59,7 @@ C70,Brunswick Green,21,56,56,Perlervault
 C71,Goldenrod,232,174,0,Perlervault
 C72,Pastel Orange,217,179,94,Perlervault
 C73,Sienna,187,104,51,Perlervault
-C74,Deer,191,145,104,Perlervault
+C74,Deer,205,178,119,jweeks2023
 C75,Clay,170,116,78,Perlervault
 C76,Coral Red,236,98,94,Perlervault
 C77,Deep Chestnut,190,93,101,Perlervault


### PR DESCRIPTION
The RGB value that is listed for C74 looks like it was directly swatched from the Artkal reference, which conflicts with the provided RGB value:
![image](https://github.com/user-attachments/assets/79d74491-7c7a-488f-b818-01f3c7688fb7)
The provided RGB value is closer to the IRL color of the bead, as opposed to the one currently listed. Below is an image with a pool of C74 beads, with the Artkal provided color on the left and your current color on the right:
![image](https://github.com/user-attachments/assets/29cdd193-0223-4955-82a0-b877ce7289e0)
Note: Just as the Artkal bead reference is inaccurate, my picture is also not 100% accurate, but of the two colors, my suggestion is more accurate to it's true color.
